### PR TITLE
Remove extra folder when generating JSON-LD

### DIFF
--- a/config/setup.cfg
+++ b/config/setup.cfg
@@ -15,6 +15,3 @@ free = 255
 laser_height = 0.7
 output_folder  = ../output/{{model_name}}/map
 border = 50
-
-[composable_models]
-output_folder = ../output/{{model_name}}/jsonld

--- a/src/exsce_floorplan/floor_plan/json_ld_transformation.py
+++ b/src/exsce_floorplan/floor_plan/json_ld_transformation.py
@@ -40,31 +40,3 @@ def jsonld_floorplan_generator(
     coordinate = build_floorplan_coordinate_graph(model, output_path)
     with open("{}/coordinate.json".format(output_path), "w") as file:
         json.dump(coordinate, file, indent=4)
-
-
-if __name__ == "__main__":
-    import sys
-    import configparser
-    from textx import metamodel_for_language
-    import traceback
-
-    try:
-        my_metamodel = metamodel_for_language("exsce-floorplan-dsl")
-        argv = sys.argv[sys.argv.index("--") + 1 :]
-        my_model = my_metamodel.model_from_file(argv[0])
-
-        config = configparser.ConfigParser()
-        config.read("setup.cfg")
-
-        output_path = config["composable_models"]["output_folder"]
-
-        if "{{model_name}}" in output_path:
-            output_path = output_path.replace("{{model_name}}", my_model.name)
-            if not os.path.exists(output_path):
-                os.makedirs(output_path)
-
-        jsonld_floorplan_generator(my_metamodel, my_model, output_path)
-
-    except Exception:
-        print(traceback.format_exc())
-        sys.exit(1)

--- a/src/exsce_floorplan/floor_plan/json_ld_transformation.py
+++ b/src/exsce_floorplan/floor_plan/json_ld_transformation.py
@@ -18,30 +18,27 @@ def jsonld_floorplan_generator(
         if not os.path.exists(output_path):
             os.makedirs(output_path)
 
+    if not os.path.exists(output_path):
+        os.makedirs(output_path)
+
     skeleton = build_skeleton_graph(model, output_path)
-    shape = build_shape_graph(model, output_path)
-    spatial_relations = build_spatial_relations_graph(model, output_path)
-    floorplan = build_floorplan_graph(model, output_path)
-    coordinate = build_floorplan_coordinate_graph(model, output_path)
-
-    directory = os.path.join(output_path, "{name}_json_ld".format(name=model.name))
-    print(directory)
-    if not os.path.exists(directory):
-        os.makedirs(directory)
-
-    with open("{}/skeleton.json".format(directory), "w") as file:
+    with open("{}/skeleton.json".format(output_path), "w") as file:
         json.dump(skeleton, file, indent=4)
 
-    with open("{}/shape.json".format(directory), "w") as file:
+    shape = build_shape_graph(model, output_path)
+    with open("{}/shape.json".format(output_path), "w") as file:
         json.dump(shape, file, indent=4)
 
-    with open("{}/spatial_relations.json".format(directory), "w") as file:
+    spatial_relations = build_spatial_relations_graph(model, output_path)
+    with open("{}/spatial_relations.json".format(output_path), "w") as file:
         json.dump(spatial_relations, file, indent=4)
 
-    with open("{}/floorplan.json".format(directory), "w") as file:
+    floorplan = build_floorplan_graph(model, output_path)
+    with open("{}/floorplan.json".format(output_path), "w") as file:
         json.dump(floorplan, file, indent=4)
 
-    with open("{}/coordinate.json".format(directory), "w") as file:
+    coordinate = build_floorplan_coordinate_graph(model, output_path)
+    with open("{}/coordinate.json".format(output_path), "w") as file:
         json.dump(coordinate, file, indent=4)
 
 


### PR DESCRIPTION
This makes it easier to use the CLI to output directly in a particular folder (e.g. to follow the structure in `floorplan_models`