### PR TITLE
Update textx example path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ textx generate <floorplan model> --target json-ld --output-path <output path>
 For example: 
 
 ```
-textx generate models/examples/brsu_building_c_with_doorways.floorplan --target json-ld --output-path .
+textx generate ../models/examples/brsu_building_c_with_doorways.floorplan --target json-ld --output-path .
 ```
 
 ### Tutorials

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ exsce-variation-dsl -> exsce-floorplan-dslexsce-floorplan[0.0.1]        Generate
 This tool is currently in active development. To use the tool you can execute the following command: 
 
 ```
-blender --background --python exsce_floorplan/exsce_floorplan.py --python-use-system-env -- <model_path>
+blender --background --python src/exsce_floorplan/exsce_floorplan.py --python-use-system-env -- <model_path>
 ```
 
 Optionally, you can remove the `--background` flag to see directly the result opened in Blender.
@@ -96,6 +96,7 @@ An example model for a building is available [here](models/examples/hospital.flo
 
 
 ```
+cd src
 blender --background --python exsce_floorplan/exsce_floorplan.py --python-use-system-env -- ../models/examples/hospital.floorplan
 ```
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,7 @@ An example model for a building is available [here](models/examples/hospital.flo
 
 
 ```
-cd src
-blender --background --python exsce_floorplan/exsce_floorplan.py --python-use-system-env -- ../models/examples/hospital.floorplan
+blender --background --python src/exsce_floorplan/exsce_floorplan.py --python-use-system-env -- models/examples/hospital.floorplan
 ```
 
 That should generate the following files:

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ textx generate <floorplan model> --target json-ld --output-path <output path>
 For example: 
 
 ```
-textx generate ../models/examples/brsu_building_c_with_doorways.floorplan --target json-ld --output-path .
+textx generate models/examples/brsu_building_c_with_doorways.floorplan --target json-ld --output-path .
 ```
 
 ### Tutorials


### PR DESCRIPTION
Example should now run out of the box if you just follow the commands in the readme from top to bottom