### PR TITLE
Add height property to floorplan elements

### DIFF
--- a/src/floorplan_dsl/templates/json-ld/floorplan/elements/element.json
+++ b/src/floorplan_dsl/templates/json-ld/floorplan/elements/element.json
@@ -2,5 +2,6 @@
             "@id": "{{ element.name }}",
             "@type": "{{ element.__class__.__name__ }}",
             "shape": "{{ element.shape.name }}",
-            "3d-shape": "{{ element.shape_3d.name }}"
+            "3d-shape": "{{ element.shape_3d.name }}",
+            "height": {{ element.height.value }}
         }

--- a/src/floorplan_dsl/templates/json-ld/floorplan/elements/wall.json
+++ b/src/floorplan_dsl/templates/json-ld/floorplan/elements/wall.json
@@ -3,5 +3,6 @@
             "@type": "{{ element.__class__.__name__ }}",
             "shape": "{{ element.shape.name }}",
             "3d-shape": "{{ element.shape_3d.name }}",
-            "thickness": {{ element.thickness.value }}
+            "thickness": {{ element.thickness.value }},
+            "height": {{ element.height.value }}
         }


### PR DESCRIPTION
The height information for certain floorplan elements (walls, columns, dividers) is only available implicitly in the `polyhedron.json` model. This adds some redundancy about the elements' height to simplify some queries in the scenery_builder.

Required for https://github.com/secorolab/scenery_builder/pull/17